### PR TITLE
Send a Ctrl+a with "Ctrl+a a"

### DIFF
--- a/tmux/tmux.conf.symlink
+++ b/tmux/tmux.conf.symlink
@@ -4,7 +4,7 @@ setw -g mode-keys vi
 # remap prefix to Control + a
 set -g prefix C-a
 unbind C-b
-bind C-a send-prefix
+bind a send-prefix
 
 # force a reload of the config file
 unbind r


### PR DESCRIPTION
You had bound "Ctrl+a Ctrl+a" twice: once in line 7 for send-prefix and then you redefine it in line 15 to cycle panes.  Leave the pane cycling to "Ctrl+a Ctrl+a" and let "Ctrl+a a" send a "Ctrl+a" to the underlying command.
